### PR TITLE
Use double quote in shell-command-to-string

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -580,7 +580,7 @@ string of results."
     (format "LANG=en_US.UTF-8 %s -n %s %s --data-dir=%s"
             sdcv-program
             (mapconcat (lambda (dict)
-                         (concat "-u '" dict "'"))
+                         (concat "-u \"" dict "\""))
                        dictionary-list " ")
             word
             sdcv-dictionary-data-dir))))


### PR DESCRIPTION
- 允许 Oxford Advanced Learner's Dictionary 类似带单引号的字典