### PR TITLE
Fix sdcv-check function.

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -450,7 +450,7 @@ and eliminates the problem that cannot be translated."
                  (shell-command-to-string
                   (format "LANG=en_US.UTF-8 %s --list-dicts --data-dir=%s" sdcv-program sdcv-dictionary-data-dir)))
                 "\n")))
-         (dict-names (mapcar (lambda (dict) (car (split-string dict " "))) dict-name-infos))
+         (dict-names (mapcar (lambda (dict) (car (split-string dict "    "))) dict-name-infos))
          (have-invalid-dict nil))
     (if sdcv-dictionary-simple-list
         (dolist (dict sdcv-dictionary-simple-list)


### PR DESCRIPTION
sdcv-check fails even though a dictionary has been installed correctly
when the dictionary name contains a space, such as "Collins Cobuild 5".
Splitting dict-name-infos with four spaces fixs this issue. Four spaces
is sensible since sdcv formats dictionary list this way.