### PR TITLE
set optional argument PROMPT of read-event to " "

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -522,7 +522,7 @@ will be displayed in buffer named with `sdcv-buffer-name' with
      :internal-border-width sdcv-tooltip-border-width
      )
     (unwind-protect
-	(push (read-event) unread-command-events)
+	(push (read-event " ") unread-command-events)
       (posframe-delete sdcv-tooltip-name))
     ;; (add-hook 'post-command-hook 'sdcv-hide-tooltip-after-move)
     (setq sdcv-tooltip-last-point (point))


### PR DESCRIPTION
To avoid function read-event displays descriptions at echo area.


![2020-11-12_19-58](https://user-images.githubusercontent.com/35016457/98937585-904c4c80-2521-11eb-8a08-9d428a6ed2f0.png)
