### PR TITLE
Refactor using json flags

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -209,6 +209,7 @@
 
 ;;; Require
 
+(require 'json)
 (require 'subr-x)
 (require 'outline)
 (require 'posframe)
@@ -446,38 +447,42 @@ And show information using tooltip."
 (defun sdcv-check ()
   "Check for missing StarDict dictionaries."
   (interactive)
-  (let* ((dict-name-infos
-          (cdr (split-string
-                (string-trim
-                 (shell-command-to-string
-                  (format "env LANG=%s %s --list-dicts --data-dir=%s" sdcv-env-lang sdcv-program sdcv-dictionary-data-dir)))
-                "\n")))
-         (dict-names (mapcar (lambda (dict) (car (split-string dict "    "))) dict-name-infos))
-         (have-invalid-dict nil))
-    (if sdcv-dictionary-simple-list
-        (dolist (dict sdcv-dictionary-simple-list)
-          (unless (member dict dict-names)
-            (setq have-invalid-dict t)
-            (message
-             "sdcv-dictionary-simple-list: dictionary '%s' does not exist, remove it from sdcv-dictionary-simple-list or download the corresponding dictionary file to %s"
-             dict
-             sdcv-dictionary-data-dir)))
-      (setq have-invalid-dict t)
-      (message "sdcv-dictionary-simple-list is empty, command sdcv-search-simple won't work as expected."))
-    (if sdcv-dictionary-complete-list
-        (dolist (dict sdcv-dictionary-complete-list)
-          (unless (member dict dict-names)
-            (setq have-invalid-dict t)
-            (message
-             "sdcv-dictionary-complete-list: dictionary '%s' does not exist, remove it from sdcv-dictionary-complete-list or download the corresponding dictionary file to %s"
-             dict
-             sdcv-dictionary-data-dir)))
-      (setq have-invalid-dict t)
-      (message "sdcv-dictionary-complete-list is empty, command sdcv-search-detail won't work as expected."))
-    (unless have-invalid-dict
-      (message "The dictionary's settings look correct, sdcv should work as expected."))))
+  (let* ((dicts (sdcv-list-dicts))
+         (missing-simple-dicts (sdcv-missing-dicts sdcv-dictionary-simple-list dicts))
+         (missing-complete-dicts (sdcv-missing-dicts sdcv-dictionary-complete-list dicts)))
+    (if (and sdcv-dictionary-simple-list (null missing-simple-dicts)
+             sdcv-dictionary-complete-list (null missing-complete-dicts))
+        (message "The dictionary's settings look correct, sdcv should work as expected.")
+      (unless sdcv-dictionary-simple-list
+        (message "sdcv-dictionary-simple-list is empty, command sdcv-search-simple won't work as expected."))
+      (dolist (dict missing-simple-dicts)
+        (message "sdcv-dictionary-simple-list: dictionary '%s' does not exist, remove it or download the corresponding dictionary file to %s"
+                 dict sdcv-dictionary-data-dir))
+      (unless sdcv-dictionary-complete-list
+        (message "sdcv-dictionary-complete-list is empty, command sdcv-search-detail won't work as expected."))
+      (dolist (dict missing-complete-dicts)
+        (message "sdcv-dictionary-complete-list: dictionary '%s' does not exist, remove it or download the corresponding dictionary file to %s"
+                 dict sdcv-dictionary-data-dir)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Utilities Functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun sdcv-list-dicts ()
+  "List dictionaries present in SDCV."
+  (with-temp-buffer
+    (save-excursion
+      (let* ((lang-env (concat "LANG=" sdcv-env-lang))
+             (process-environment (cons lang-env process-environment))
+             (arguments (list "--data-dir" sdcv-dictionary-data-dir
+                              "--json-output" "--list-dicts")))
+        (apply #'call-process sdcv-program nil t nil arguments)))
+    (mapcar (lambda (dict) (cdr (assq 'name dict))) (json-read))))
+
+(defun sdcv-missing-dicts (list &optional dicts)
+  "List missing LIST dictionaries in DICTS.
+If DICTS is nil, compute present dictionaries with
+`sdcv--list-dicts'."
+  (let ((dicts (or dicts (sdcv-list-dicts))))
+    (cl-set-difference list dicts :test #'string=)))
 
 (defun sdcv-search-detail (&optional word)
   "Search WORD in `sdcv-dictionary-complete-list'.

--- a/sdcv.el
+++ b/sdcv.el
@@ -260,6 +260,11 @@ finish system installation."
   :type '(choice (const :tag "Default" nil) directory)
   :group 'sdcv)
 
+(defcustom sdcv-only-data-dir t
+  "Search is performed using only `sdcv-dictionary-data-dir'."
+  :type 'boolean
+  :group 'sdcv)
+
 (defcustom sdcv-tooltip-border-width 10
   "The border width of sdcv tooltip, in pixels."
   :type 'integer
@@ -292,9 +297,6 @@ coding if your system is not zh_CN.UTF-8."
 
 (defvar sdcv-current-translate-object nil
   "The search object.")
-
-(defvar sdcv-filter-string "^对不起，没有发现和.*\n"
-  "The filter string that sdcv outputs.")
 
 (defvar sdcv-fail-notify-string "没有发现解释也... \n用更多的词典查询一下吧! ^_^"
   "User notification message on failed search.")
@@ -450,32 +452,37 @@ And show information using tooltip."
   (let* ((dicts (sdcv-list-dicts))
          (missing-simple-dicts (sdcv-missing-dicts sdcv-dictionary-simple-list dicts))
          (missing-complete-dicts (sdcv-missing-dicts sdcv-dictionary-complete-list dicts)))
-    (if (and sdcv-dictionary-simple-list (null missing-simple-dicts)
-             sdcv-dictionary-complete-list (null missing-complete-dicts))
+    (if (not (or missing-simple-dicts missing-complete-dicts))
         (message "The dictionary's settings look correct, sdcv should work as expected.")
-      (unless sdcv-dictionary-simple-list
-        (message "sdcv-dictionary-simple-list is empty, command sdcv-search-simple won't work as expected."))
       (dolist (dict missing-simple-dicts)
         (message "sdcv-dictionary-simple-list: dictionary '%s' does not exist, remove it or download the corresponding dictionary file to %s"
                  dict sdcv-dictionary-data-dir))
-      (unless sdcv-dictionary-complete-list
-        (message "sdcv-dictionary-complete-list is empty, command sdcv-search-detail won't work as expected."))
       (dolist (dict missing-complete-dicts)
         (message "sdcv-dictionary-complete-list: dictionary '%s' does not exist, remove it or download the corresponding dictionary file to %s"
                  dict sdcv-dictionary-data-dir)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Utilities Functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun sdcv-list-dicts ()
-  "List dictionaries present in SDCV."
+(defun sdcv-call-process (&rest arguments)
+  "Call `sdcv-program' with ARGUMENTS.
+Result is parsed as json."
   (with-temp-buffer
     (save-excursion
       (let* ((lang-env (concat "LANG=" sdcv-env-lang))
-             (process-environment (cons lang-env process-environment))
-             (arguments (list "--data-dir" sdcv-dictionary-data-dir
-                              "--json-output" "--list-dicts")))
-        (apply #'call-process sdcv-program nil t nil arguments)))
-    (mapcar (lambda (dict) (cdr (assq 'name dict))) (json-read))))
+             (process-environment (cons lang-env process-environment)))
+        (apply #'call-process sdcv-program nil t nil
+               (append (list "--non-interactive" "--json-output")
+                       (when sdcv-only-data-dir
+                         (list "--only-data-dir"))
+                       (when sdcv-dictionary-data-dir
+                         (list "--data-dir" sdcv-dictionary-data-dir))
+                       arguments))))
+    (ignore-errors (json-read))))
+
+(defun sdcv-list-dicts ()
+  "List dictionaries present in SDCV."
+  (mapcar (lambda (dict) (cdr (assq 'name dict)))
+          (sdcv-call-process "--list-dicts")))
 
 (defun sdcv-missing-dicts (list &optional dicts)
   "List missing LIST dictionaries in DICTS.
@@ -575,29 +582,16 @@ Argument DICTIONARY-LIST the word that needs to be transformed."
 (defun sdcv-translate-result (word dictionary-list)
   "Call sdcv to search WORD in DICTIONARY-LIST.
 Return filtered string of results."
-  (sdcv-filter
-   (shell-command-to-string
-    ;; Set LANG environment variable, make sure `shell-command-to-string' can handle CJK character correctly.
-    (format "env LANG=%s %s -x -n %s %s --data-dir=%s"
-            sdcv-env-lang
-            sdcv-program
-            (mapconcat (lambda (dict)
-                         (concat "-u \"" dict "\""))
-                       dictionary-list " ")
-            (format "\"%s\"" word)
-            sdcv-dictionary-data-dir))))
-
-(defun sdcv-filter (sdcv-string)
-  "Filter sdcv output string.
-Argument SDCV-STRING the search string from sdcv."
-  (setq sdcv-string (replace-regexp-in-string sdcv-filter-string "" sdcv-string))
-  (if (equal sdcv-string "")
-      sdcv-fail-notify-string
-    (with-temp-buffer
-      (insert sdcv-string)
-      (goto-char (point-min))
-      (kill-line 1)                   ;remove unnecessary information.
-      (buffer-string))))
+  (let* ((arguments (cons word (mapcan (lambda (d) (list "-u" d)) dictionary-list)))
+         (result (mapconcat
+                  (lambda (result)
+                    (let-alist result
+                      (format "-->%s\n-->%s\n%s\n\n" .dict .word .definition)))
+                  (apply #'sdcv-call-process arguments)
+                  "")))
+    (if (string-empty-p result)
+        sdcv-fail-notify-string
+      result)))
 
 (defun sdcv-goto-sdcv ()
   "Switch to sdcv buffer in other window."


### PR DESCRIPTION
Refactor all calls to `sdcv` program using `--json-output`. This enables much better control over data. Also, this is a first step towards the realization of `ewoc` interface referenced in #27 

For now, the format string on line 589 is copied directly from `sdcv` code, it should produce the same output.