### PR TITLE
Make posframe optional dependency

### DIFF
--- a/sdcv.el
+++ b/sdcv.el
@@ -2,7 +2,7 @@
 
 ;; Filename: sdcv.el
 ;; Description: Interface for sdcv (StartDict console version).
-;; Package-Requires: ((emacs "25.1") (posframe "1.1.2"))
+;; Package-Requires: ((emacs "25.1"))
 ;; Author: Andy Stewart <lazycat.manatee@gmail.com>
 ;; Maintainer: Andy Stewart <lazycat.manatee@gmail.com>
 ;; Copyright (C) 2009, Andy Stewart, all rights reserved.
@@ -69,7 +69,7 @@
 ;;
 ;;      sudo aptitude install stardict sdcv -y
 ;;
-;; And make sure you have installed `posframe.el'.
+;; Optionally, you can install `posframe.el'.
 ;; You can get it from:
 ;; https://raw.githubusercontent.com/tumashu/posframe/master/posframe.el
 ;;
@@ -209,11 +209,14 @@
 
 ;;; Require
 
+(require 'cl-lib)
 (require 'json)
-(require 'subr-x)
 (require 'outline)
-(require 'posframe)
+(require 'subr-x)
 (require 'subword)
+
+(autoload 'posframe-show "posframe")
+(declare-function posframe-delete "ext:posframe")
 
 ;;; Code:
 


### PR DESCRIPTION
I propose to make posframe an optional dependency. I'm not using it and I don't want to install dependencies that are not essential to the package. 